### PR TITLE
add builder specific information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ clap = { version = "4.4", features = ["derive", "env"] }
 commit = { git = "https://github.com/EspressoSystems/commit.git" }
 derive_more = "0.99"
 futures = "0.3"
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1" }
+#hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "main" }
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/block_info.rs
+++ b/src/block_info.rs
@@ -38,20 +38,20 @@ impl<I: NodeType> Committable for HashableBlock<I> {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
-pub struct BlockMetadata<I: NodeType> {
+pub struct AvailableBlockInfo<I: NodeType> {
     pub block_hash: BuilderCommitment,
     pub block_size: u64,
     pub offered_fee: u64,
     pub signature: <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    pub _phantom: PhantomData<I>,
     pub sender: <I as NodeType>::SignatureKey,
+    pub _phantom: PhantomData<I>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
-pub struct Blockdata<I: NodeType> {
+pub struct AvailableBlockData<I: NodeType> {
     pub block_payload: <I as NodeType>::BlockPayload,
     pub signature: <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    pub _phantom: PhantomData<I>,
     pub sender: <I as NodeType>::SignatureKey,
+    pub _phantom: PhantomData<I>,
 }

--- a/src/block_metadata.rs
+++ b/src/block_metadata.rs
@@ -1,7 +1,10 @@
 use std::{hash::Hash, marker::PhantomData};
 
 use commit::{Commitment, Committable};
-use hotshot_types::traits::{node_implementation::NodeType, BlockPayload};
+use hotshot_types::{
+    traits::{node_implementation::NodeType, BlockPayload, signature_key::SignatureKey},
+    utils::BuilderCommitment
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -33,11 +36,22 @@ impl<I: NodeType> Committable for HashableBlock<I> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
 pub struct BlockMetadata<I: NodeType> {
-    block_hash: BlockHash<I>,
-    block_size: u64,
-    offered_fee: u64,
-    _phantom: PhantomData<I>,
+    pub block_hash: BuilderCommitment,
+    pub block_size: u64,
+    pub offered_fee: u64,
+    pub signature: <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    pub _phantom: PhantomData<I>,
+    pub sender: <I as NodeType>::SignatureKey,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(bound = "")]
+pub struct Blockdata<I: NodeType> {
+    pub block_payload: <I as NodeType>::BlockPayload,
+    pub signature: <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    pub _phantom: PhantomData<I>,
+    pub sender: <I as NodeType>::SignatureKey,
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, path::PathBuf};
 use clap::Args;
 use derive_more::From;
 use futures::FutureExt;
-use hotshot_types::traits::{node_implementation::NodeType, signature_key::SignatureKey};
+use hotshot_types::{traits::{node_implementation::NodeType, signature_key::SignatureKey}, utils::BuilderCommitment};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tagged_base64::TaggedBase64;
@@ -95,7 +95,7 @@ where
         })?
         .get("claim_block", |req, state| {
             async move {
-                let hash = req.blob_param("block_hash")?;
+                let hash:BuilderCommitment = req.blob_param("block_hash")?;
                 let signature = req.blob_param("signature")?;
                 state
                     .claim_block(&hash, &signature)

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -7,7 +7,7 @@ use hotshot_types::{
 use tagged_base64::TaggedBase64;
 
 use crate::{
-    block_metadata::{BlockMetadata, Blockdata},
+    block_info::{AvailableBlockInfo, AvailableBlockData},
     builder::BuildError,
 };
 
@@ -21,11 +21,11 @@ where
     async fn get_available_blocks(
         &self,
         for_parent: &VidCommitment,
-    ) -> Result<Vec<BlockMetadata<I>>, BuildError>;
+    ) -> Result<Vec<AvailableBlockInfo<I>>, BuildError>;
     async fn claim_block(
         &self,
         block_hash: &BuilderCommitment,
         signature: &<<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<Blockdata<I>, BuildError>;
+    ) -> Result<AvailableBlockData<I>, BuildError>;
     async fn submit_txn(&self, txn: <I as NodeType>::Transaction) -> Result<(), BuildError>;
 }

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -2,11 +2,12 @@ use async_trait::async_trait;
 use hotshot_types::{
     data::VidCommitment,
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
+    utils::BuilderCommitment
 };
 use tagged_base64::TaggedBase64;
 
 use crate::{
-    block_metadata::{BlockHash, BlockMetadata},
+    block_metadata::{BlockMetadata, Blockdata},
     builder::BuildError,
 };
 
@@ -23,8 +24,8 @@ where
     ) -> Result<Vec<BlockMetadata<I>>, BuildError>;
     async fn claim_block(
         &self,
-        block_hash: &BlockHash<I>,
+        block_hash: &BuilderCommitment,
         signature: &<<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
-    ) -> Result<I::BlockPayload, BuildError>;
+    ) -> Result<Blockdata<I>, BuildError>;
     async fn submit_txn(&self, txn: <I as NodeType>::Transaction) -> Result<(), BuildError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod api;
-pub mod block_metadata;
+pub mod block_info;
 pub mod builder;
 pub mod data_source;
 pub mod query_data;

--- a/src/query_data.rs
+++ b/src/query_data.rs
@@ -6,10 +6,10 @@
 use hotshot_types::traits::node_implementation::NodeType;
 use serde::{Deserialize, Serialize};
 
-use crate::block_metadata::BlockMetadata;
+use crate::block_info::AvailableBlockInfo;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
 pub struct AvailableBlocksQueryData<I: NodeType> {
-    pub blocks: Vec<BlockMetadata<I>>,
+    pub blocks: Vec<AvailableBlockInfo<I>>,
 }

--- a/src/query_data.rs
+++ b/src/query_data.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::block_metadata::BlockMetadata;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(bound = "")]
 pub struct AvailableBlocksQueryData<I: NodeType> {
     pub blocks: Vec<BlockMetadata<I>>,


### PR DESCRIPTION
It adds some extra information to api's response from the builder. Moreover, it also imports `BuilderCommitment` from `Hotshot`.