### PR TITLE
running cargo fmt

### DIFF
--- a/src/block_info.rs
+++ b/src/block_info.rs
@@ -2,8 +2,8 @@ use std::{hash::Hash, marker::PhantomData};
 
 use commit::{Commitment, Committable};
 use hotshot_types::{
-    traits::{node_implementation::NodeType, BlockPayload, signature_key::SignatureKey},
-    utils::BuilderCommitment
+    traits::{node_implementation::NodeType, signature_key::SignatureKey, BlockPayload},
+    utils::BuilderCommitment,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,10 @@ use std::{fmt::Display, path::PathBuf};
 use clap::Args;
 use derive_more::From;
 use futures::FutureExt;
-use hotshot_types::{traits::{node_implementation::NodeType, signature_key::SignatureKey}, utils::BuilderCommitment};
+use hotshot_types::{
+    traits::{node_implementation::NodeType, signature_key::SignatureKey},
+    utils::BuilderCommitment,
+};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tagged_base64::TaggedBase64;
@@ -95,7 +98,7 @@ where
         })?
         .get("claim_block", |req, state| {
             async move {
-                let hash:BuilderCommitment = req.blob_param("block_hash")?;
+                let hash: BuilderCommitment = req.blob_param("block_hash")?;
                 let signature = req.blob_param("signature")?;
                 state
                     .claim_block(&hash, &signature)

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -2,12 +2,12 @@ use async_trait::async_trait;
 use hotshot_types::{
     data::VidCommitment,
     traits::{node_implementation::NodeType, signature_key::SignatureKey},
-    utils::BuilderCommitment
+    utils::BuilderCommitment,
 };
 use tagged_base64::TaggedBase64;
 
 use crate::{
-    block_info::{AvailableBlockInfo, AvailableBlockData},
+    block_info::{AvailableBlockData, AvailableBlockInfo},
     builder::BuildError,
 };
 


### PR DESCRIPTION
So, you should set up automatic `cargo fmt`...

In VS Code, you can go to Settings->Text Editor->Formatting and check Format On Save, or add `"editor.formatOnSave": true,` to your global `settings.json` file.

We should also add a github pre-commit action for that at some point.