### PR TITLE
Updates for the API

### DIFF
--- a/api/submit.toml
+++ b/api/submit.toml
@@ -21,45 +21,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
 [meta]
-NAME = "hs-builder-get"
+NAME = "hs-builder-submit"
 DESCRIPTION = ""
 FORMAT_VERSION = "0.1.0"
 
-[route.available_blocks]
-PATH = ["availableblocks/:parent_hash"]
-":parent_hash" = "TaggedBase64"
-DOC = """
-Get descriptions for all block candidates based on a specific parent block.
-
-Returns
-```
-[
-    "block_metadata": {
-        "block_hash":  TaggedBase64,
-        "block_size":  integer,
-        "offered_fee": integer,
-    },
-]
-```
-"""
-
-[route.claim_block]
-PATH = ["claimblock/:block_hash/:signature"]
-":block_hash" = "TaggedBase64"
-":signature" = "TaggedBase64"
-DOC = """
-Get the specified block candidate.
-
-Returns application-specific encoded transactions type
-"""
-
-[route.claim_header]
-PATH = ["claimheader/:block_hash/:signature"]
-":block_hash" = "TaggedBase64"
-":signature" = "TaggedBase64"
-DOC = """
-Get the specified block candidate.
-
-Returns application-specific block header type
-"""
+[route.submit_txn]
+PATH = ["/submit"]
+METHOD = "POST"
+DOC = "Submit a transaction to builder's private mempool."

--- a/src/block_info.rs
+++ b/src/block_info.rs
@@ -25,3 +25,12 @@ pub struct AvailableBlockData<I: NodeType> {
     pub sender: <I as NodeType>::SignatureKey,
     pub _phantom: PhantomData<I>,
 }
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(bound = "")]
+pub struct AvailableBlockHeader<I: NodeType> {
+    pub block_header: <I as NodeType>::BlockHeader,
+    pub signature: <<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    pub sender: <I as NodeType>::SignatureKey,
+    pub _phantom: PhantomData<I>,
+}

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -7,7 +7,7 @@ use hotshot_types::{
 use tagged_base64::TaggedBase64;
 
 use crate::{
-    block_info::{AvailableBlockData, AvailableBlockInfo},
+    block_info::{AvailableBlockData, AvailableBlockHeader, AvailableBlockInfo},
     builder::BuildError,
 };
 
@@ -27,5 +27,17 @@ where
         block_hash: &BuilderCommitment,
         signature: &<<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
     ) -> Result<AvailableBlockData<I>, BuildError>;
-    async fn submit_txn(&self, txn: <I as NodeType>::Transaction) -> Result<(), BuildError>;
+    async fn claim_block_header(
+        &self,
+        block_hash: &BuilderCommitment,
+        signature: &<<I as NodeType>::SignatureKey as SignatureKey>::PureAssembledSignatureType,
+    ) -> Result<AvailableBlockHeader<I>, BuildError>;
+}
+
+#[async_trait]
+pub trait AcceptsTxnSubmits<I>
+where
+    I: NodeType,
+{
+    async fn submit_txn(&mut self, txn: <I as NodeType>::Transaction) -> Result<(), BuildError>;
 }


### PR DESCRIPTION
This contains the known required API updates.

For `hs-builder-core`, we can create a struct `GlobalStateTxnSubmitter` that owns a clone of the `Arc<RwLock<GlobalState<NodeType>>>`, and implement `AcceptsTxnSubmits` on that, e.g.

```rust
pub struct GlobalStateTxnSubmitter<I: NodeType> {
    pub global_state_handle: Arc<RwLock<GlobalState<I>>>,
}

impl<I: NodeType> AcceptsTxnSubmits<I> for GlobalStateTxnSubmitter<I> {
    async fn submit_txn(&mut self, txn: <I as NodeType>::Transaction) -> Result<(), BuildError> {
        self.global_state_handle.read()?.submit_txn(txn)
    }
}
```

The `GlobalState` function for `submit_txn` will need access to a `tx_sender: BroadcastSender<MessageType<Types>>`, and can then be

```rust
    async fn submit_txn(&self, txn: <Types as BuilderType>::Transaction) -> Result<(), BuildError> {
        let tx_msg = TransactionMessage::<Types> {
            tx: txn,
            tx_type: TransactionSource::HotShot,
        };
        self.tx_sender
            .broadcast(MessageType::TransactionMessage(tx_msg))
            .await
            .map(|a| ())
            .map_err(|e| BuildError::Error {
                message: fmt!("failed to send txn"),
            })
    }

```