### PR TITLE
Move to Latest HotShot-Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,9 +2115,10 @@ dependencies = [
 
 [[package]]
 name = "hotshot-types"
-version = "0.1.8"
-source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.8#db908cc340bc9db9ec193c2400ee9594e04c93f0"
+version = "0.1.9"
+source = "git+https://github.com/EspressoSystems/hotshot-types?tag=0.1.9#4c8dffbb3b47c35d9bc465cc6520d06da578f9ec"
 dependencies = [
+ "anyhow",
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hs-builder-api"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 clap = { version = "4.4", features = ["derive", "env"] }
 derive_more = "0.99"
 futures = "0.3"
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.8" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", branch = "jparr721/issue-2621" }
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.3.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 clap = { version = "4.4", features = ["derive", "env"] }
 derive_more = "0.99"
 futures = "0.3"
-hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", branch = "jparr721/issue-2621" }
+hotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", tag = "0.1.9" }
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 tagged-base64 = { git = "https://github.com/EspressoSystems/tagged-base64", tag = "0.3.4" }


### PR DESCRIPTION
Add Block Storage Trait for Storing DA and VID DIsperse Certs.

References [#2621 ](https://github.com/EspressoSystems/HotShot/issues/2621)
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
We want to integrate a persistent storage interface within HotShot to enable the application to manage data storage effectively. This feature aims to address potential data storage issues (e.g., full disk space) that can prevent nodes from storing DA blobs or VID shares.

### This PR: 
1. Gets the latest `HotShot-Types` trait which **Creates the `Storage` Trait** and methods for interacting with the data store, whose implementation is to be provided by anyone who needs it.

### This PR does not: 
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review: 
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
